### PR TITLE
Fix fod for Oss Vendor

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -344,6 +344,18 @@ vendor/etc/init/init.batterysecret.rc
 # Display
 vendor/lib64/hw/displayfeature.default.so
 
+#Display-HWComposer
+system_ext/lib/vendor.qti.hardware.display.composer@3.0.so
+system_ext/lib64/vendor.qti.hardware.display.composer@3.0.so
+vendor/bin/hw/vendor.qti.hardware.display.composer-service
+-vendor/etc/vintf/manifest/vendor.qti.hardware.display.composer-service.xml
+vendor/etc/init/vendor.qti.hardware.display.composer-service.rc
+vendor/lib/vendor.qti.hardware.display.composer@1.0.so
+vendor/lib/vendor.qti.hardware.display.composer@2.0.so
+vendor/lib64/vendor.qti.hardware.display.composer@3.0.so
+vendor/lib64/vendor.qti.hardware.display.composer@1.0.so
+vendor/lib64/vendor.qti.hardware.display.composer@2.0.so
+
 # Fingerprint
 vendor/bin/hw/android.hardware.biometrics.fingerprint@2.1-service
 vendor/etc/init/android.hardware.biometrics.fingerprint@2.1-service.rc


### PR DESCRIPTION
Fod_impl: https://github.com/dataoutputstream/device_xiaomi_sm8250_common/commit/ce0e669a660830af0238ef8e0de9798cbd5e2c58#diff-40c8c5469f953906025db90f6621bd41d33944e585aa4f39a487ebe7a5c69f5f
Framework_base_needed_code: https://github.com/dataoutputstream/platform_frameworks_base/commit/86a2a0901b8af99019996286decbc6510f77e375